### PR TITLE
Support selecting the camera for recording

### DIFF
--- a/Sentry/Localizable.xcstrings
+++ b/Sentry/Localizable.xcstrings
@@ -97,6 +97,16 @@
         }
       }
     },
+    "Camera" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摄像头"
+          }
+        }
+      }
+    },
     "Camera Access Denied" : {
       "localizations" : {
         "zh-Hans" : {

--- a/Sentry/SentryConfiguration.swift
+++ b/Sentry/SentryConfiguration.swift
@@ -160,4 +160,5 @@ struct SentryConfiguration: Codable, Equatable, Hashable {
     }
 
     var sentryRecordingEnabled: Bool = false
+    var sentryRecordingDevice: String? = nil
 }


### PR DESCRIPTION
Hello, I often use this app in the school library and public study rooms. It works very well, but sometimes, when I connect my MacBook Pro to displays with cameras (such as Studio Display and LG UltraFine 5K), I want to record using the camera on the display. So I added this feature.